### PR TITLE
EmdTrefftz: use Integrator to generate bfi/lfis

### DIFF
--- a/src/embtrefftz.cpp
+++ b/src/embtrefftz.cpp
@@ -104,7 +104,7 @@ namespace ngcomp
         for (auto icf : bf->icfs)
         {
             auto & dx = icf->dx;
-            bfis[dx.vb] += make_shared<SymbolicBilinearFormIntegrator> (icf->cf, dx.vb, dx.element_vb);
+            bfis[dx.vb] += icf->MakeBilinearFormIntegrator();
         }
 
         Array<shared_ptr<LinearFormIntegrator>> lfis[4];
@@ -112,7 +112,7 @@ namespace ngcomp
             for (auto icf : lf->icfs)
             {
                 auto & dx = icf->dx;
-                lfis[dx.vb] += make_shared<SymbolicLinearFormIntegrator> (icf->cf, dx.vb, dx.element_vb);
+                lfis[dx.vb] += icf->MakeLinearFormIntegrator();
             }
 
         shared_ptr<SparseMatrix<SCAL>> P;


### PR DESCRIPTION
Using the integrator here would allow for other DifferentialSymbols to be used in the Embedded Trefftz context (e.g. ngsxfem). 